### PR TITLE
remove rebar3_hex plugin from rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,2 @@
 {erl_opts, [debug_info]}.
-{plugins, [rebar3_hex]}.
 {deps, []}.


### PR DESCRIPTION
since provider_asn1 does not need rebar3_hex, it must not introduce the
(plugin) dependency.

the use case where rebar3_hex is used to publish provider_asn1 is better
served by adding {plugins, [rebar3_hex]}. to the global configuration
(~/.config/rebar3/rebar.config).
