### PR TITLE
Only create directories and recompile when necessary

### DIFF
--- a/src/provider_asn1_compile.erl
+++ b/src/provider_asn1_compile.erl
@@ -72,24 +72,25 @@ process_app(State, AppPath) ->
     IncludePath = filename:join(AppPath, "include"),
     SrcPath = filename:join(AppPath, "src"),
 
-    Asns = find_asn_files(ASNPath),
-    verbose_out(State, "    Asns: ~p", [Asns]),
-    verbose_out(State, "Making ~p ~p~n", [GenPath, file:make_dir(GenPath)]),
-    lists:foreach(fun(AsnFile) -> generate_asn(State, GenPath, AsnFile) end, Asns),
+    case find_asn_files(ASNPath) of
+        [] ->
+            ok;
+        Asns ->
+            verbose_out(State, "    Asns: ~p", [Asns]),
+            verbose_out(State, "Making ~p ~p~n", [GenPath, file:make_dir(GenPath)]),
+            lists:foreach(fun(AsnFile) -> generate_asn(State, GenPath, AsnFile) end, Asns),
 
-    verbose_out(State, "ERL files: ~p", [filelib:wildcard("*.erl", GenPath)]),
-    move_files(State, GenPath, SrcPath, "*.erl"),
+            verbose_out(State, "ERL files: ~p", [filelib:wildcard("*.erl", GenPath)]),
+            move_files(State, GenPath, SrcPath, "*.erl"),
 
-    verbose_out(State, "DB files: ~p", [filelib:wildcard("*.asn1db", GenPath)]),
-    move_files(State, GenPath, SrcPath, "*.asn1db"),
+            verbose_out(State, "DB files: ~p", [filelib:wildcard("*.asn1db", GenPath)]),
+            move_files(State, GenPath, SrcPath, "*.asn1db"),
 
-    verbose_out(State, "HEADER files: ~p", [filelib:wildcard("*.hrl", GenPath)]),
-    move_files(State, GenPath, IncludePath, "*.hrl"),
+            verbose_out(State, "HEADER files: ~p", [filelib:wildcard("*.hrl", GenPath)]),
+            move_files(State, GenPath, IncludePath, "*.hrl"),
 
-    verbose_out(State, "BEAM files: ~p", [filelib:wildcard("*.beam", GenPath)]),
-    delete_files(State, GenPath, "*.beam"),
-
-    ok.
+            ok
+    end.
 
 format_error(Reason) ->
     provider_asn1_util:format_error(Reason).
@@ -107,5 +108,5 @@ generate_asn(State, Path, AsnFile) ->
             true -> [Encoding, verbose, {outdir, Path}];
             _ -> [Encoding, {outdir, Path}]
         end ++ proplists:get_value(compile_opts, Args),
-    verbose_out(State, "Beginning compile with opts: ~p", [CompileArgs]),
+    verbose_out(State, "Beginning compile with opts: ~p", [noobj | CompileArgs]),
     asn1ct:compile(AsnFile, CompileArgs).

--- a/src/provider_asn1_compile.erl
+++ b/src/provider_asn1_compile.erl
@@ -108,7 +108,7 @@ generate_asn(State, Path, AsnFile) ->
             true -> [Encoding, verbose, {outdir, Path}];
             _ -> [Encoding, {outdir, Path}]
         end ++ proplists:get_value(compile_opts, Args),
-    verbose_out(State, "Beginning compile with opts: ~p", [noobj | CompileArgs]),
+    verbose_out(State, "Beginning compile with opts: ~p", CompileArgs),
     asn1ct:compile(AsnFile, CompileArgs).
 
 to_recompile(ASNPath, GenPath) ->


### PR DESCRIPTION
Hi,

Would you consider this pull request ? 
## Create working directories only when necessary

This is a cosmetic change. When using rebar3 to compile on release top level the provider also createdsthe working directories. With this change it only creates them if it has something to do (i.e. ASN.1 files found in the application)
## Adding noobj to options instead of deleting generated beam files

This is a cosmetic change. It does not result in any significant speedup.
## Avoid unconditional recompilation

ASN.1 generation is rather slow with more than a few files. During development of an application having ASN.1 files it is somewhat frustrating to have it with each recompilation unconditionally. With this change it compiles when any of the ASN.1 dictionaries have been updated (i.e. modification time is later than the corresponding generated .erl file).

Cheers,
Ferenc
