### PR TITLE
fix verbose_out of CompileArgs

### DIFF
--- a/src/provider_asn1_compile.erl
+++ b/src/provider_asn1_compile.erl
@@ -108,7 +108,7 @@ generate_asn(State, Path, AsnFile) ->
             true -> [Encoding, verbose, {outdir, Path}];
             _ -> [Encoding, {outdir, Path}]
         end ++ proplists:get_value(compile_opts, Args),
-    verbose_out(State, "Beginning compile with opts: ~p", CompileArgs),
+    verbose_out(State, "Beginning compile with opts: ~p", [CompileArgs]),
     asn1ct:compile(AsnFile, CompileArgs).
 
 to_recompile(ASNPath, GenPath) ->


### PR DESCRIPTION
86e6218a648fdc86acde004d0e490158c6951c72 and later f9623036f7e528fa8225dc85abe43b9030f9a03c result in badarg (from invalid fromat string in io:format/3) when CompileArgs is not a one-element list.