### PR TITLE
Allow .asn extensions

### DIFF
--- a/src/provider_asn1_clean.erl
+++ b/src/provider_asn1_clean.erl
@@ -51,7 +51,7 @@ do_clean(State, AppPath) ->
     Asns = filelib:wildcard("**/*.{asn1,asn}", AsnPath),
     lists:foreach(
         fun(AsnFile) ->
-            Base = provider_asn1_util:asn_basename(AsnFile, ".asn1"),
+            Base = provider_asn1_util:asn_basename(AsnFile),
             provider_asn1_util:delete_file(State, SrcPath, Base ++ ".erl"),
             provider_asn1_util:delete_file(State, IncludePath, Base ++ ".hrl")
         end, Asns),

--- a/src/provider_asn1_clean.erl
+++ b/src/provider_asn1_clean.erl
@@ -48,10 +48,10 @@ do_clean(State, AppPath) ->
     IncludePath = filename:join(AppPath, "include"),
     SrcPath = filename:join(AppPath, "src"),
 
-    Asns = filelib:wildcard("**/*.asn1", AsnPath),
+    Asns = filelib:wildcard("**/*.{asn1,asn}", AsnPath),
     lists:foreach(
         fun(AsnFile) ->
-            Base = filename:basename(AsnFile, ".asn1"),
+            Base = provider_asn1_util:asn_basename(AsnFile, ".asn1"),
             provider_asn1_util:delete_file(State, SrcPath, Base ++ ".erl"),
             provider_asn1_util:delete_file(State, IncludePath, Base ++ ".hrl")
         end, Asns),

--- a/src/provider_asn1_compile.erl
+++ b/src/provider_asn1_compile.erl
@@ -74,7 +74,7 @@ process_app(State, AppPath) ->
 move_asns(State, GenPath, SrcPath, IncludePath, Asns) ->
     lists:foreach(
       fun(AsnFile) ->
-              Base = asn_basename(AsnFile),
+              Base = provider_asn1_util:asn_basename(AsnFile),
               provider_asn1_util:move_file(State, GenPath, Base ++ ".erl", SrcPath),
               provider_asn1_util:delete_file(State, GenPath, Base ++ ".asn1db"),
               provider_asn1_util:move_file(State, GenPath, Base ++ ".hrl", IncludePath)
@@ -119,9 +119,6 @@ find_asn_files(Path) ->
 
 is_latest(ASNFileName, ASNPath, GenPath) ->
     Source = filename:join(ASNPath, ASNFileName),
-    TargetFileName = asn_basename(ASNFileName) ++ ".erl",
+    TargetFileName = provider_asn1_util:asn_basename(ASNFileName) ++ ".erl",
     Target = filename:join(GenPath, TargetFileName),
     filelib:last_modified(Source) > filelib:last_modified(Target).
-
-asn_basename(ASNFileName) ->
-    filename:basename(filename:basename(ASNFileName, ".asn1"), ".asn").

--- a/src/provider_asn1_compile.erl
+++ b/src/provider_asn1_compile.erl
@@ -74,7 +74,7 @@ process_app(State, AppPath) ->
 move_asns(State, GenPath, SrcPath, IncludePath, Asns) ->
     lists:foreach(
       fun(AsnFile) ->
-              Base = filename:basename(AsnFile, ".asn1"),
+              Base = asn_basename(AsnFile),
               provider_asn1_util:move_file(State, GenPath, Base ++ ".erl", SrcPath),
               provider_asn1_util:delete_file(State, GenPath, Base ++ ".asn1db"),
               provider_asn1_util:move_file(State, GenPath, Base ++ ".hrl", IncludePath)
@@ -115,10 +115,13 @@ to_recompile(ASNPath, GenPath) ->
                     find_asn_files(ASNPath)).
 
 find_asn_files(Path) ->
-    [filename:join(Path, F) || F <- filelib:wildcard("**/*.asn1", Path)].
+    [filename:join(Path, F) || F <- filelib:wildcard("**/*.{asn1,asn}", Path)].
 
 is_latest(ASNFileName, ASNPath, GenPath) ->
     Source = filename:join(ASNPath, ASNFileName),
-    TargetFileName = filename:basename(ASNFileName, ".asn1") ++ ".erl",
+    TargetFileName = asn_basename(ASNFileName) ++ ".erl",
     Target = filename:join(GenPath, TargetFileName),
     filelib:last_modified(Source) > filelib:last_modified(Target).
+
+asn_basename(ASNFileName) ->
+    filename:basename(filename:basename(ASNFileName, ".asn1"), ".asn").

--- a/src/provider_asn1_util.erl
+++ b/src/provider_asn1_util.erl
@@ -7,7 +7,9 @@
          resolve_args/2,
          get_args/1,
          get_arg/2,
-         set_arg/3]).
+         set_arg/3,
+         asn_basename/1
+        ]).
 
 verbose_out(State, FormatString, Args)->
     CommArgs = get_args(State),

--- a/src/provider_asn1_util.erl
+++ b/src/provider_asn1_util.erl
@@ -71,3 +71,6 @@ set_arg(State, Key, Val) ->
     Args = rebar_state:get(State, asn1_args, []),
     ArgsMap = maps:from_list(Args),
     rebar_state:set(State, asn1_args, maps:to_list(maps:put(Key, Val, ArgsMap))).
+
+asn_basename(ASNFileName) ->
+    filename:basename(filename:basename(filename:basename(ASNFileName, ".asn1"), ".asn"), ".set").


### PR DESCRIPTION
Make it possible to compile files with both `.asn` and `.asn1` extensions.

Reference: https://www.erlang.org/doc/man/asn1ct.html

> If Asn1module is a filename without extension, first ".asn1" is assumed, then ".asn", and finally ".py" (to be compatible with the old ASN.1 compiler). Asn1module can be a full pathname (relative or absolute) including filename with (or without) extension.

> If it is needed to compile a set of ASN.1 modules into an Erlang file with encode/decode functions, ensure to list all involved files in a configuration file. This configuration file must have a double extension ".set.asn" (".asn" can alternatively be ".asn1" or ".py"). List the input file names within quotation marks (""), one at each row in the file. If the input files are File1.asn, File2.asn, and File3.asn, the configuration file must look as follows: