### PR TITLE
Compile order of ASN.1 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,18 @@ They can be placed in your `rebar.config` file, or issued on the command line.
 
 The options are as follows:
  * `--verbose -v` Lots of output for debugging.
- * `--encoding -e` Pick the encoding used by the asn compiler. Options are `ber`, `per`, and `uper`. `ber` is the default.
- * `--compile_opts -o` A comma-separated list of options to send to erlang's asn.1 compiler. See http://erlang.org/doc/man/asn1ct.html#compile-2 for available options.
+ * `--encoding -e` Pick the encoding used by the asn compiler. Options
+   are `ber`, `per`, and `uper`. `ber` is the default.
+ * `--compile_opts -o` A comma-separated list of options to send to
+   Erlang's ASN.1 compiler. See
+   http://erlang.org/doc/man/asn1ct.html#compile-2 for available
+   options.
+ * `--compile_order -c` An Erlang term consisting of a tuple-list of
+   the specific order to compile the ASN.1 files where the first
+   tuple-element is one of `wildcard` | `file` | `dir` and the second
+   the filename in string format. Defaults to
+   `[{wildcard, \"**/*.asn1\"}]`.
+
 
 Example:
 ```

--- a/src/provider_asn1_compile.erl
+++ b/src/provider_asn1_compile.erl
@@ -26,8 +26,10 @@ init(State) ->
                     {compile_opts, $o, "compile_opts", binary,
                      "A comma-separated list of options to send to Erlang's ASN.1 compiler."},
                     {compile_order, $c, "compile_order", binary,
-                     "A comma-separated list of {wildcard | file | dir, string} the specific order "
-                     "to compile the ASN.1 files. {wildcard, \"**/*.asn1\"} as default"}
+                     "An Erlang term consisting of a tuple-list of the specific order "
+                     "to compile the ASN.1 files where the first tuple-element is "
+                     "one of `wildcard' | `file' | `dir' and the second the filename "
+                     "in string format. Defaults to `[{wildcard, \"**/*.asn1\"}]'."}
                    ]},
             {short_desc, "Compile ASN.1 with Rebar3"},
             {desc, "Compile ASN.1 with Rebar3"}

--- a/src/provider_asn1_compile.erl
+++ b/src/provider_asn1_compile.erl
@@ -135,6 +135,10 @@ find_asn_files(State, BasePath) ->
   -if(?OTP_RELEASE >= 25).
 uniq(Fs) ->
     lists:uniq(Fs).
+  -elif(?OTP_RELEASE < 25).
+uniq(Fs) ->
+    Fs.
+  -endif.
 -else.
 uniq(Fs) ->
     Fs.


### PR DESCRIPTION
Make it possible to compile ASN.1s that are dependent on other ASN.1s
but would be compiled at a later stage due to the name or directory.

Example
```
  {compile_order, [{file, "etsi_ETR091_ed1_9307/MobileDomainDefinitions.asn1"},
                   {dir, "itu-t_X.880_9407"},
                   {dir, "itu-t_Q.773_9706"},
                   {dir, "ts29.002-v17.2.0"},
                   {wildcard, "**/*.asn1"}
                  ]}
```
Many of the ASN.1 files here depend on MobileDomainDefinitions, and ts29.002 depend on Q.773 which depend on X.880.
You get weird errors if they are not compiled in the right order.