### PR TITLE
Add compile option overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ The options are as follows:
  * `--verbose -v` Lots of output for debugging.
  * `--encoding -e` Pick the encoding used by the asn compiler. Options are `ber`, `per`, and `uper`. `ber` is the default.
  * `--compile_opts -o` A comma-separated list of options to send to erlang's asn.1 compiler. See http://erlang.org/doc/man/asn1ct.html#compile-2 for available options.
+ * `--overrides -O` An Erlang term consisting of a tuple-list of the
+   compile options that will override the options per file. The first
+   tuple-element is one of `file` | `re` and the second the filename
+   or match pattern in string format.
 
 Example:
 ```
@@ -109,7 +113,10 @@ As mentioned, these options can be put in your `rebar.config` file:
 ```
 {asn1_args, [{encoding, per},
              {verbose, true},
-             {compile_opts, [der, compact_bit_string]}]}.
+             {compile_opts, [der, compact_bit_string]},
+             {overrides, [{{file, "CAP_PHASE1.set.asn1"}, [{encoding, [ber]},
+                                                           {compile_opts, [{i, "asn1-lib/"}]}]},
+                          {{re, "/uper/"}, [{encoding, uper}]}]}]}.
 ```
 
 Options in `rebar.config` will be overridden by command-line options.

--- a/src/provider_asn1_compile.erl
+++ b/src/provider_asn1_compile.erl
@@ -29,10 +29,10 @@ init(State) ->
                      "An Erlang term consisting of a tuple-list of the specific order "
                      "to compile the ASN.1 files where the first tuple-element is "
                      "one of `wildcard' | `file' | `dir' and the second the filename "
-                     "in string format. Defaults to `[{wildcard, \"**/*.asn1\"}]'."}
-                   ]},
+                     "in string format. Defaults to `[{wildcard, \"**/*.asn1\"}]'."},
                     {overrides, $O, "overrides", binary,
-                     "An Erlang term [{file | re, string}, [Opt]}] with specific options."}]},
+                     "An Erlang term [{file | re, string}, [Opt]}] with specific options."}
+                   ]},
             {short_desc, "Compile ASN.1 with Rebar3"},
             {desc, "Compile ASN.1 with Rebar3"}
     ]),

--- a/src/provider_asn1_compile.erl
+++ b/src/provider_asn1_compile.erl
@@ -143,9 +143,9 @@ is_latest(ASNFileName, ASNPath, GenPath) ->
     filelib:last_modified(Source) > filelib:last_modified(Target).
 
 apply_file_overrides(File, Args) ->
-    {[OverridesArgs], OtherArgs} = proplists:split(Args, [file_overrides]),
+    {[OverridesArgs], OtherArgs} = proplists:split(Args, [overrides]),
     case OverridesArgs of
-        [{file_overrides, Overrides}] -> match_file_overrides(File, Overrides);
+        [{overrides, Overrides}] -> match_file_overrides(File, Overrides);
         []                            -> []
     end ++ OtherArgs.
 

--- a/src/provider_asn1_compile.erl
+++ b/src/provider_asn1_compile.erl
@@ -22,22 +22,40 @@ init(State) ->
             % list of options understood by the plugin
             {opts, [{verbose, $v, "verbose", boolean, "Be Verbose."},
                     {encoding, $e, "encoding", atom, "The encoding to use (atom). ber by default."},
-                    {compile_opts, $o, "compile_opts", binary, "A comma-separated list of options to send to erlang's asn.1 compiler."}]},
+                    {compile_opts, $o, "compile_opts", binary, "A comma-separated list of options to send to erlang's asn.1 compiler."},
+                    {overrides, $O, "overrides", binary,
+                     "An Erlang term [{file | re, string}, [Opt]}] with specific options."}]},
             {short_desc, "Compile ASN.1 with Rebar3"},
             {desc, "Compile ASN.1 with Rebar3"}
     ]),
     {ok, rebar_state:add_provider(State, Provider)}.
 
 resolve_special_args(PreState) ->
-    NewState = provider_asn1_util:resolve_args(PreState, ?DEFAULTS),
-    CompileOpts = provider_asn1_util:get_arg(NewState, compile_opts),
+    DefaultState = provider_asn1_util:resolve_args(PreState, ?DEFAULTS),
+    lists:foldl(fun (F, State) -> F(State) end,
+                DefaultState,
+                [fun resolve_compile_opts/1,
+                 fun resolve_compile_overrides/1
+                ]).
+
+resolve_compile_opts(State) ->
+    CompileOpts = provider_asn1_util:get_arg(State, compile_opts),
     if
         is_binary(CompileOpts) ->
             NewCompileOpts = lists:map(fun(X) ->
                                                binary_to_atom(X, utf8) end,
                                        re:split(CompileOpts, ",")),
-            provider_asn1_util:set_arg(NewState, compile_opts, NewCompileOpts);
-        true -> NewState
+            provider_asn1_util:set_arg(State, compile_opts, NewCompileOpts);
+        true -> State
+    end.
+resolve_compile_overrides(State) ->
+    FileCompileOpts = provider_asn1_util:get_arg(State, overrides),
+    if
+        is_binary(FileCompileOpts) ->
+            {ok, Toks, _} = erl_scan:string(binary_to_list(FileCompileOpts) ++ "."),
+            {ok, NewFileCompileOpts} = erl_parse:parse_term(Toks),
+            provider_asn1_util:set_arg(State, overrides, NewFileCompileOpts);
+        true -> State
     end.
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
@@ -67,7 +85,7 @@ process_app(State, AppPath) ->
         Asns ->
             ensure_dir(State, GenPath),
             ensure_dir(State, IncludePath),
-            lists:foreach(fun(AsnFile) -> generate_asn(State, GenPath, AsnFile) end, Asns),
+            lists:foreach(fun(AsnFile) -> generate_asn(State, GenPath, AsnFile, AppPath) end, Asns),
             move_asns(State, GenPath, SrcPath, IncludePath, Asns)
     end.
 
@@ -84,14 +102,15 @@ move_asns(State, GenPath, SrcPath, IncludePath, Asns) ->
 format_error(Reason) ->
     provider_asn1_util:format_error(Reason).
 
-generate_asn(State, Path, AsnFile) ->
+generate_asn(State, Path, AsnFile, AppPath) ->
     rebar_api:info("~s", [AsnFile]),
-    Args = provider_asn1_util:get_args(State),
+    Args = apply_file_overrides(AsnFile, provider_asn1_util:get_args(State)),
     provider_asn1_util:verbose_out(State, "Args: ~p", [Args]),
     Encoding = proplists:get_value(encoding, Args),
     Verbose = proplists:get_value(verbose, Args),
+    CompileOpts = fix_paths(AppPath, proplists:get_value(compile_opts, Args)),
     CompileArgs = [verbose || Verbose] ++ [noobj, Encoding, {outdir, Path}]
-        ++ proplists:get_value(compile_opts, Args),
+        ++ CompileOpts,
     provider_asn1_util:verbose_out(State, "Beginning compile with opts: ~p", [CompileArgs]),
     case asn1ct:compile(AsnFile, CompileArgs) of
         {error, E} ->
@@ -122,3 +141,32 @@ is_latest(ASNFileName, ASNPath, GenPath) ->
     TargetFileName = filename:basename(ASNFileName, ".asn1") ++ ".erl",
     Target = filename:join(GenPath, TargetFileName),
     filelib:last_modified(Source) > filelib:last_modified(Target).
+
+apply_file_overrides(File, Args) ->
+    {[OverridesArgs], OtherArgs} = proplists:split(Args, [file_overrides]),
+    case OverridesArgs of
+        [{file_overrides, Overrides}] -> match_file_overrides(File, Overrides);
+        []                            -> []
+    end ++ OtherArgs.
+
+match_file_overrides(_File, []) -> [];
+match_file_overrides(File, [{{file, BName}, Args}|Rest]) ->
+    case filename:basename(File) of
+        BName -> Args;
+        _     -> match_file_overrides(File, Rest)
+    end;
+match_file_overrides(File, [{{re, Pat}, Args}|Rest]) ->
+    case re:run(File, Pat, [{capture, none}]) of
+        nomatch -> match_file_overrides(File, Rest);
+        match   -> Args
+    end;
+match_file_overrides(File, [ _ | Rest ]) ->
+    match_file_overrides(File, Rest).
+
+fix_paths(AppPath, Args) ->
+    % there are issues when using relative paths in nested applications,
+    % make them absolut be prepending the AppPath.
+    lists:map(fun
+        ({i, Path}) -> {i, filename:absname(Path, AppPath)};
+        (Arg)       -> Arg
+    end, Args).

--- a/src/provider_asn1_compile.erl
+++ b/src/provider_asn1_compile.erl
@@ -109,8 +109,7 @@ generate_asn(State, Path, AsnFile, AppPath) ->
     Encoding = proplists:get_value(encoding, Args),
     Verbose = proplists:get_value(verbose, Args),
     CompileOpts = fix_paths(AppPath, proplists:get_value(compile_opts, Args)),
-    CompileArgs = [verbose || Verbose] ++ [noobj, Encoding, {outdir, Path}]
-        ++ CompileOpts,
+    CompileArgs = CompileOpts ++ [verbose || Verbose] ++ [noobj, Encoding, {outdir, Path}],
     provider_asn1_util:verbose_out(State, "Beginning compile with opts: ~p", [CompileArgs]),
     case asn1ct:compile(AsnFile, CompileArgs) of
         {error, E} ->


### PR DESCRIPTION
CLOSES: #8

# Option to override configuration per file or match pattern.

One can now specify a list of tuples with some file-pattern and the overrides it should do for that file-pattern.
Use `{file, Filename}` for overriding specific files, and `{re, Regex}` to override for all files with full path matching the regex. 

## Example for including another directory when compiling asn1s with similar names but different content.
```
{asn1_args, [
   ....
  {overrides, [
    {{file, "CAP_PHASE1.set.asn1"}, [{compile_opts, [{i, "cap_v1/"}]}]},
    {{file, "CAP_PHASE2.set.asn1"}, [{compile_opts, [{i, "cap_v2/"}]}]}
]}.
```


## Example if the user has a directory structure containing files with different encoding.
```
{asn1_args, [
   ....
  {overrides, [
    {{re, "/per-files/"}, [{encoding, per}]},
    {{re, "/uper-files/"}, [{encoding, uper}]}                     
]}.
```
e.g. for directory structure:
- project/asn1/per-files
- project/asn1/ber-files
- project/asn1/uper-files