### PR TITLE
only compile older target source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,6 @@ As mentioned, these options can be put in your `rebar.config` file:
 ```
 
 Options in `rebar.config` will be overridden by command-line options.
+
+Note: `provider_asn1` will recompile files if the generated source
+files are older than the asn1-files.

--- a/src/provider_asn1_compile.erl
+++ b/src/provider_asn1_compile.erl
@@ -97,7 +97,7 @@ process_app(State, AppPath) ->
     SrcPath = filename:join(AppPath, "src"),
     ensure_dir(State, SrcPath),
 
-    case to_recompile(State, ASNPath, GenPath) of
+    case to_recompile(State, ASNPath, SrcPath) of
         [] ->
             ok;
         Asns ->
@@ -144,9 +144,9 @@ ensure_dir(State, Path) ->
             provider_asn1_util:verbose_out(State, "Making ~p ~p~n", [Path, file:make_dir(Path)])
     end.
 
-to_recompile(State, ASNPath, GenPath) ->
+to_recompile(State, ASNPath, SrcPath) ->
     lists:filtermap(fun (File) ->
-                            is_latest(File, ASNPath, GenPath)
+                            is_latest(State, File, ASNPath, SrcPath)
                     end,
                     find_asn_files(State, ASNPath)).
 
@@ -175,10 +175,10 @@ uniq(Fs) ->
     Fs.
 -endif.
 
-is_latest(ASNFileName, ASNPath, GenPath) ->
+is_latest(State, ASNFileName, ASNPath, SrcPath) ->
     Source = filename:join(ASNPath, ASNFileName),
     TargetFileName = provider_asn1_util:asn_basename(ASNFileName) ++ ".erl",
-    Target = filename:join(GenPath, TargetFileName),
+    Target = filename:join(SrcPath, TargetFileName),
     filelib:last_modified(Source) > filelib:last_modified(Target).
 
 apply_file_overrides(File, Args) ->


### PR DESCRIPTION
Currently the files under asngen are moved after succesful generation. This results in rebar3 needing to recompile the ASN.1 files every time.

Instead of comparing modification dates between the generated files (in asngen/), and the original ASN.1-files (in asn1/), the moved generated source files (in src/) should be used for comparison.

This can introduce some issues due to the dependency-files `asn1db` beeing deleted in between, but I recon it should save a lot of time in the 99% cases. Maybe we could introduce a parameter flag `save_generated` which could be set to true if one wants to keep the dependency graph-files around.